### PR TITLE
new sidebar entry for data releases

### DIFF
--- a/_data/sidebars/artic_sidebar.yml
+++ b/_data/sidebars/artic_sidebar.yml
@@ -70,3 +70,11 @@ entries:
       url: /zika_virus.html
       output: web, pdf
 
+  - title: Data Releases
+    output: web, pdf
+    folderitems:
+    - title: PHE data release 2019
+      url: /phe_data_release_2019.html
+      output: web, pdf
+
+

--- a/pages/artic/phe_data_release_2019.md
+++ b/pages/artic/phe_data_release_2019.md
@@ -1,0 +1,47 @@
+---
+title: Data releases from the ARTIC network 
+keywords: ebola data
+last_updated: September 1, 2019
+tags: [data, ebola, nipah]
+summary:
+sidebar: artic_sidebar
+permalink: phe_data_release_2019.html
+toc: false
+folder: artic
+---
+
+> Data from our visit to Public Health England, August 2019.
+
+
+## Ebola virus
+
+| run name          | date       | barcodes                                                     | protocol(s)                                     | kit       | flow cell ID | run folder download                                                          | bulk file download                                                                                                                     |
+| ----------------- | ---------- | ------------------------------------------------------------ | ----------------------------------------------- | --------- | ------------ | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| EBOV Metagenomics | 30.08.2019 | 9=mayinga, <br/> 10=kikwit, <br/> 11=makona | 9n | rapid PCR | FAK25288 | [download](http://artic.s3.climb.ac.uk/run-folders/EBOV_Metagenomics.tar.gz) | [download](http://artic.s3.climb.ac.uk/bulkfiles/lab-on-an-ssd_20190830_112023_FAK25288_minion_sequencing_run_EBOV_Metagenomics.fast5) |
+| EBOV Metagenomics Smartplex | 30.08.2019 | 9=mayinga, <br/> 10=kikwit, <br/> 11=makona | smartplex | rapid PCR | FAK25413 | [download](http://artic.s3.climb.ac.uk/run-folders/EBOV_Metagenomics_smartplex.tar.gz) | [download](http://artic.s3.climb.ac.uk/bulkfiles/lab-on-an-ssd_20190830_123031_FAK25413_minion_sequencing_run_EBOV_Metagenomics_smartplex.fast5) |
+| EBOV Amplicons | 30.08.2019 | 3=mayinga, <br/> 4=kikwit, <br/> 5=makona, <br/> 6=negative | smartplex | native ligation PCR | FAL30025 | [download](http://artic.s3.climb.ac.uk/run-folders/EBOV_Amplicons.tar.gz) | [download](http://artic.s3.climb.ac.uk/bulkfiles/lab-on-an-ssd_20190830_155508_FAL30025_minion_sequencing_run_EBOV_Amplicons.fast5) |
+| EBOV Amplicons Flongle | 30.08.2019 | 3=mayinga, <br/> 4=kikwit, <br/> 5=makona, <br/> 6=negative | smartplex | native ligation PCR | AAQ411 | [download](http://artic.s3.climb.ac.uk/run-folders/EBOV_Amplicons_flongle.tar.gz) | [download](http://artic.s3.climb.ac.uk/bulkfiles/lab-on-an-ssd_20190830_160932_AAQ411_minion_sequencing_run_EBOV_Amplicons_flongle.fast5) |
+
+***
+
+## Nipah virus
+
+| run name          | date       | barcodes                                                     | protocol(s)                                     | kit       | flow cell ID | run folder download                                                          | bulk file download                                                                                                                     |
+| ----------------- | ---------- | ------------------------------------------------------------ | ----------------------------------------------- | --------- | ------------ | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| NiV Metagenomics | 29.08.2019 | 7=NiV, <br/> 8=NiV | 7=9n, <br/> 8=smartplex | rapid PCR | FAK25288 | [download](http://artic.s3.climb.ac.uk/run-folders/NiV_Metagenomics.tar.gz) | [download](http://artic.s3.climb.ac.uk/bulkfiles/lab-on-an-ssd_20190829_123148_FAK25288_minion_sequencing_run_NiV_metagenomics.fast5) |
+| NiV Amplicons | 30.08.2019 | - | smartplex | native ligation PCR | FAK25288 | [download](http://artic.s3.climb.ac.uk/run-folders/NiV_Amplicons.tar.gz) | [download](http://artic.s3.climb.ac.uk/bulkfiles/lab-on-an-ssd_20190830_153606_FAK25288_minion_sequencing_run_NiV_amplicons.fast5) |
+
+
+> note: the FAK25288 flow cell was subject to a nuclease flush between runs
+
+
+{% include icon-callout.html
+type='default'
+file='wellcome-logo-red-small.png'
+url='http://wellcome.ac.uk'
+width='17%'
+title='Funded by the Wellcome Trust'
+subtitle='Collaborators Award 206298/Z/17/Z --- <a href="artic.network">ARTIC network</a>'
+%}
+
+{% include links.html %}


### PR DESCRIPTION
Hi!

We would like to add the nanopore metadata and download links from our recent trip to PHE.

Summary:

* adding folder to sidebar for data releases
* adding data release page for recent PHE visit (data for EBOV and NiV)

The rational behind the new nav entry for data releases is that we have data from multiple viruses generated from a single site visit (some using the same flow cells). We are likely to have more data releases like this in the future.

Sorry for the unsolicited pull request - if you want this information added differently let me know and I can update. 
